### PR TITLE
Added NoSuchInstance (0x81), EndOfMibView (0x82) BER types handling

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -82,6 +82,9 @@ const (
 	AsnGetNextRequest BERType = 0xa1
 	AsnGetResponse    BERType = 0xa2
 	AsnGetBulkRequest BERType = 0xa5
+
+	NoSuchInstance BERType = 0x81
+	EndOfMibView   BERType = 0x82
 )
 
 // Type to indicate which SNMP version is in use.
@@ -269,6 +272,10 @@ func DecodeSequence(toparse []byte) ([]interface{}, error) {
 				return nil, err
 			}
 			result = append(result, pdu)
+		case NoSuchInstance:
+			return nil, fmt.Errorf("No such instance. Received bytes: %v", toparse)
+		case EndOfMibView:
+			return nil, fmt.Errorf("End of mib view. Received bytes: %v", toparse)
 		default:
 			return nil, fmt.Errorf("did not understand type %v", berType)
 		}

--- a/ber_test.go
+++ b/ber_test.go
@@ -137,3 +137,10 @@ func TestSequenceDecoding(t *testing.T) {
 		}
 	}
 }
+
+func TestDecodeNoSuchInstance(t *testing.T) {
+	_, err := DecodeSequence([]byte{0x30, 0x0b, 0x06, 0x07, 0x2b, 0x06, 0x01, 0x02, 0x01, 0x01, 0x03, 0x81, 0x00})
+	if err == nil {
+		t.Error("Error not reported as expected")
+	}
+}


### PR DESCRIPTION
I added handling of 2 additional BER types so that error messages are clear in case you err when specifying OIDs.
