### PR TITLE
Golint fixes, configurable timeout, line lenght

### DIFF
--- a/ber.go
+++ b/ber.go
@@ -25,19 +25,19 @@ import (
 	"time"
 )
 
-// Constants for the Type of the TLV field.
+//BERType is a constant for the Type of the TLV field.
 type BERType uint8
 
-// Type to distinguish Counter32 from just an int
+//Counter is a type to distinguish Counter32 from just an int
 type Counter int
 
-// Type to distinguish Gauge32 from just an int
+//Gauge is a type to distinguish Gauge32 from just an int
 type Gauge int
 
-// Type to distinguish Counter64 from just an int
+//Counter64 is a type to distinguish Counter64 from just an int
 type Counter64 int
 
-// Type to distinguish Gauge64 from just an int
+//Gauge64 is a type to distinguish Gauge64 from just an int
 type Gauge64 int
 
 // Constants for the different types of the TLV fields.
@@ -87,7 +87,7 @@ const (
 	EndOfMibView   BERType = 0x82
 )
 
-// Type to indicate which SNMP version is in use.
+//SNMPVersion is a type to indicate which SNMP version is in use.
 type SNMPVersion uint8
 
 // List the supported snmp versions.
@@ -123,14 +123,13 @@ func EncodeLength(length int) []byte {
 	return result
 }
 
-/* DecodeLength returns the length and the length of the length or an error.
-
-   Caveats: Does not support indefinite length. Couldn't find any
-   SNMP packet dump actually using that.
-*/
+//DecodeLength returns the length and the length of the length or an error.
+//Caveats: Does not support indefinite length. Couldn't find any
+//SNMP packet dump actually using that.
 func DecodeLength(toparse []byte) (int, int, error) {
-	// If the first bit is zero, the rest of the first byte indicates the length. Values up to 127 are encoded this way (unless you're using indefinite length, but we don't support that)
-
+	//If the first bit is zero, the rest of the first byte indicates the length.
+	//Values up to 127 are encoded this way (unless you're using indefinite
+	//length, but we don't support that)
 	if toparse[0] == 0x80 {
 		return 0, 0, fmt.Errorf("we don't support indefinite length encoding")
 	}
@@ -138,7 +137,8 @@ func DecodeLength(toparse []byte) (int, int, error) {
 		return int(toparse[0]), 1, nil
 	}
 
-	// If the first bit is one, the rest of the first byte encodes the length of then encoded length. So read how many bytes are part of the length.
+	// If the first bit is one, the rest of the first byte encodes the length
+	//of then encoded length. So read how many bytes are part of the length.
 	numOctets := int(toparse[0] & 0x7f)
 	if len(toparse) < 1+numOctets {
 		return 0, 0, fmt.Errorf("invalid length")
@@ -154,9 +154,8 @@ func DecodeLength(toparse []byte) (int, int, error) {
 	return val, 1 + numOctets, nil
 }
 
-/* DecodeInteger decodes an integer.
-
-   Will error out if it's longer than 64 bits. */
+//DecodeInteger decodes an integer.
+//Will error out if it's longer than 64 bits.
 func DecodeInteger(toparse []byte) (int, error) {
 	if len(toparse) > 8 {
 		return 0, fmt.Errorf("don't support more than 64 bits")

--- a/ber.go
+++ b/ber.go
@@ -167,7 +167,7 @@ func DecodeInteger(toparse []byte) (int, error) {
 	return val, nil
 }
 
-// EncodeInteger encodes an integer to BER format.
+//EncodeInteger encodes an integer to BER format.
 func EncodeInteger(toEncode int) []byte {
 	// Calculate the length we'll need for the encoded value.
 	l := 1
@@ -177,7 +177,7 @@ func EncodeInteger(toEncode int) []byte {
 		l++
 	}
 
-	// Now create a byte array of the correct length and copy the value into it.
+	//Now create a byte array of the correct length and copy the value into it.
 	result := make([]byte, l)
 	for i = 0; i < l; i++ {
 		result[i] = byte(toEncode >> uint(8*(l-i-1)))
@@ -185,7 +185,7 @@ func EncodeInteger(toEncode int) []byte {
 	return result
 }
 
-// DecodeSequence decodes BER binary data into into *[]interface{}.
+//DecodeSequence decodes BER binary data into into *[]interface{}.
 func DecodeSequence(toparse []byte) ([]interface{}, error) {
 	var result []interface{}
 
@@ -209,7 +209,7 @@ func DecodeSequence(toparse []byte) ([]interface{}, error) {
 
 	lidx := 0
 	idx := 1 + seqLenLen
-	// Let's guarantee progress.
+	//Let's guarantee progress.
 	for idx < len(toparse) && idx > lidx {
 		berType := toparse[idx]
 		berLength, berLenLen, err := DecodeLength(toparse[idx+1:])

--- a/example.go
+++ b/example.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func DoGetTableTest(target string) {
+func doGetTableTest(target string) {
 	community := "public"
 	version := SNMPv2c
 
@@ -29,7 +29,7 @@ func DoGetTableTest(target string) {
 	}
 }
 
-func DoWalkTest(target string) {
+func doWalkTest(target string) {
 	community := "public"
 	version := SNMPv2c
 
@@ -54,19 +54,10 @@ func DoWalkTest(target string) {
 
 			oid = MustParseOid(o)
 		}
-		/*  Old version without GETBULK
-		    result_oid, val, err := wsnmp.GetNext(oid)
-		    if err != nil {
-		      fmt.Printf("GetNext error => %v\n", err)
-		      return
-		    }
-		    fmt.Printf("GetNext(%v, %v, %v, %v) => %s, %v\n", target, community, version, oid, result_oid, val)
-		    oid = *result_oid
-		*/
 	}
 }
 
-func DoGetTest(target string) {
+func doGetTest(target string) {
 	community := "public"
 	version := SNMPv2c
 

--- a/oid.go
+++ b/oid.go
@@ -1,7 +1,6 @@
 package wapsnmp
 
 /* Encode decode OIDs.
-
    References : http://rane.com/note161.html
 */
 
@@ -12,13 +11,12 @@ import (
 	"strings"
 )
 
-// The SNMP object identifier type.
+//Oid is the SNMP object identifier type.
 type Oid []int
 
-// String returns the string representation for this oid object.
+//String returns the string representation for this oid object.
 func (o Oid) String() string {
-	/* A zero-length Oid has to be valid as it's often used as the start of a
-	   Walk. */
+	//A zero-length Oid has to be valid as it's often used as the start of a Walk.
 	if len(o) == 0 {
 		return "."
 	}
@@ -29,7 +27,7 @@ func (o Oid) String() string {
 	return result
 }
 
-// MustParseOid parses a string oid to an Oid instance. Panics on error.
+//MustParseOid parses a string oid to an Oid instance. Panics on error.
 func MustParseOid(o string) Oid {
 	result, err := ParseOid(o)
 	if err != nil {
@@ -38,7 +36,7 @@ func MustParseOid(o string) Oid {
 	return result
 }
 
-// ParseOid a text format oid into an Oid instance.
+//ParseOid a text format oid into an Oid instance.
 func ParseOid(oid string) (Oid, error) {
 	// Special case "." = [], "" = []
 	if oid == "." || oid == "" {
@@ -61,7 +59,7 @@ func ParseOid(oid string) (Oid, error) {
 	return result, nil
 }
 
-// DecodeOid decodes a ASN.1 BER raw oid into an Oid instance.
+//DecodeOid decodes a ASN.1 BER raw oid into an Oid instance.
 func DecodeOid(raw []byte) (*Oid, error) {
 	if len(raw) < 2 {
 		return nil, errors.New("oid is at least 2 bytes long")
@@ -87,53 +85,48 @@ func DecodeOid(raw []byte) (*Oid, error) {
 	return &r, nil
 }
 
-// Encode encodes the oid into an ASN.1 BER byte array.
+//Encode encodes the oid into an ASN.1 BER byte array.
 func (o Oid) Encode() ([]byte, error) {
 	if len(o) < 3 {
 		return nil, errors.New("oid needs to be at least 3 long")
 	}
 	var result []byte
-	if o[0] != 1 || o[1] != 3 {
-		return nil, errors.New("oid didn't start with .1.3")
-	}
-	/* Every o is supposed to start with 40 * first_byte + second 
-	   byte */
+	//Every o is supposed to start with 40 * first_byte + second byte
 	start := (40 * o[0]) + o[1]
 	result = append(result, byte(start))
 	for i := 2; i < len(o); i++ {
 		val := o[i]
 
-		toadd := make([]int, 0)
+		var toAdd []int
 		if val == 0 {
-			toadd = append(toadd, 0)
+			toAdd = append(toAdd, 0)
 		}
 		for val > 0 {
-			toadd = append(toadd, val%128)
+			toAdd = append(toAdd, val%128)
 			val /= 128
 		}
 
-		for i := len(toadd) - 1; i >= 0; i-- {
-			sevenbits := toadd[i]
+		for i := len(toAdd) - 1; i >= 0; i-- {
+			sevenBits := toAdd[i]
 			if i != 0 {
-				result = append(result, 128+byte(sevenbits))
+				result = append(result, 128+byte(sevenBits))
 			} else {
-				result = append(result, byte(sevenbits))
+				result = append(result, byte(sevenBits))
 			}
 		}
 	}
 	return result, nil
 }
 
-// Copy copies an oid into a new object instance.
+//Copy copies an oid into a new object instance.
 func (o Oid) Copy() Oid {
 	dest := make([]int, len(o))
 	copy(dest, o)
 	return Oid(dest)
 }
 
-/* Within determines if an oid has this oid instance as a prefix.
-
-E.g. MustParseOid("1.2.3").Within("1.2") => true. */
+//Within determines if an oid has this oid instance as a prefix.
+//E.g. MustParseOid("1.2.3").Within("1.2") => true.
 func (o Oid) Within(other Oid) bool {
 	if len(other) > len(o) {
 		return false

--- a/snmp.go
+++ b/snmp.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// The object type that lets you do SNMP requests.
+//WapSNMP is the object type that lets you do SNMP requests.
 type WapSNMP struct {
 	Target    string        // Target device for these SNMP events.
 	Community string        // Community to use to contact the device.
@@ -34,9 +34,8 @@ func NewWapSNMP(target, community string, version SNMPVersion, timeout time.Dura
 	return &WapSNMP{target, community, version, timeout, retries, conn}, nil
 }
 
-/* NewWapSNMPOnConn creates a new WapSNMP object from an existing net.Conn.
-
-It does not check if the provided target is valid.*/
+//NewWapSNMPOnConn creates a new WapSNMP object from an existing net.Conn.
+//It does not check if the provided target is valid.*/
 func NewWapSNMPOnConn(target, community string, version SNMPVersion, timeout time.Duration, retries int, conn net.Conn) *WapSNMP {
 	return &WapSNMP{target, community, version, timeout, retries, conn}
 }
@@ -90,7 +89,7 @@ func (w WapSNMP) Get(oid Oid) (interface{}, error) {
 	}
 
 	response := make([]byte, bufSize, bufSize)
-	numRead, err := poll(w.conn, req, response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, req, response, w.retries, w.timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +123,7 @@ func (w WapSNMP) GetMultiple(oids []Oid) (map[string]interface{}, error) {
 	}
 
 	response := make([]byte, bufSize, bufSize)
-	numRead, err := poll(w.conn, req, response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, req, response, w.retries, w.timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +147,7 @@ func (w WapSNMP) GetMultiple(oids []Oid) (map[string]interface{}, error) {
 	return result, nil
 }
 
-// GetNext issues a GETNEXT SNMP request.
+//GetNext issues a GETNEXT SNMP request.
 func (w WapSNMP) GetNext(oid Oid) (*Oid, interface{}, error) {
 	requestID := getRandomRequestID()
 	req, err := EncodeSequence([]interface{}{Sequence, int(w.Version), w.Community,
@@ -160,7 +159,7 @@ func (w WapSNMP) GetNext(oid Oid) (*Oid, interface{}, error) {
 	}
 
 	response := make([]byte, bufSize)
-	numRead, err := poll(w.conn, req, response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, req, response, w.retries, w.timeout)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -181,10 +180,9 @@ func (w WapSNMP) GetNext(oid Oid) (*Oid, interface{}, error) {
 	return &resultOid, resultVal, nil
 }
 
-/* GetBulk is semantically the same as maxRepetitions getnext requests, but in a single GETBULK SNMP packet.
-
-   Caveat: many devices will silently drop GETBULK requests for more than some number of maxrepetitions, if
-   it doesn't work, try with a lower value and/or use GetTable. */
+//GetBulk is semantically the same as maxRepetitions getnext requests, but in a single GETBULK SNMP packet.
+//Caveat: many devices will silently drop GETBULK requests for more than some number of maxrepetitions, if
+//it doesn't work, try with a lower value and/or use GetTable.
 func (w WapSNMP) GetBulk(oid Oid, maxRepetitions int) (map[string]interface{}, error) {
 	requestID := getRandomRequestID()
 	req, err := EncodeSequence([]interface{}{Sequence, int(w.Version), w.Community,

--- a/snmp.go
+++ b/snmp.go
@@ -194,7 +194,7 @@ func (w WapSNMP) GetBulk(oid Oid, maxRepetitions int) (map[string]interface{}, e
 	}
 
 	response := make([]byte, bufSize, bufSize)
-	numRead, err := poll(w.conn, req, response, w.retries, 500*time.Millisecond)
+	numRead, err := poll(w.conn, req, response, w.retries, w.timeout)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Made the code pass Golint, removed some old example code, passed the timeout everywhere, removed the check for if the OID begins with 1.3 (as some begin with 1.2). 
